### PR TITLE
Added gzip and caching, improved security

### DIFF
--- a/spiffing.php
+++ b/spiffing.php
@@ -141,9 +141,24 @@
 			foreach( $replacements as $search => $replace ) {
 				$processed = str_ireplace( $search, $replace, $this->css );
 			}
-			// Set the CSS header.
+						
+			// Set caching and content-type
+			$expiry = 604800; // One week
+			$this->set_header('Pragma: public');
+			$this->set_header('Cache-Control: max-age=' . $expiry);
+			$this->set_header('Expires: ' . gmdate('D, d M Y H:i:s', time() + $expiry) . ' GMT');
 			$this->set_header('Content-Type: text/css');
+			
+			// Enable gzip
+			if (extension_loaded('zlib')) {
+				ob_start('ob_gzhandler');
+			} else {
+				ob_start();
+			}
+			
 			echo $processed;
+			
+			ob_end_flush();
 			exit;
 		}
 		/*

--- a/spiffing.php
+++ b/spiffing.php
@@ -104,6 +104,14 @@
 				if( !file_exists( $this->file ) or !is_readable( $file ) ) {
 					$this->not_found();
 				}
+				
+				
+				// Validate input file is a CSS file
+				$ext = pathinfo($this->file, PATHINFO_EXTENSION);
+				if ($ext != 'css') {
+					$this->not_found();
+				}
+				
 				$this->css = file_get_contents( $this->file );
 			} else {
 				// No spiffing CSS was found.


### PR DESCRIPTION
In the interests of jolly good page performance and for mobile folk, bandwidth consumption this patch will conditionally enable gzip compression if zlib is loaded, and by default will allow the browser to cache CSS for one week.

Also improves security by validating input file is CSS. This will prevent directory traversal attacks from inputs like ../../../../etc/passwd etc.
