### PR TITLE
Removed transparency/opacity

### DIFF
--- a/spiffing.php
+++ b/spiffing.php
@@ -44,7 +44,6 @@
 			'colour'		=> 'color',
 			'grey'			=> 'gray',
 			'!please'		=> '!important',
-			'transparency'		=> 'opacity',
 			'centre'		=> 'center',
 			'plump'			=> 'bold',
 			'photograph'		=> 'image',


### PR DESCRIPTION
Transparency is the opposite of opacity, so if it’s in there the value must be subtracted from 1.0. e.g. `transparency: 0.1` should output as `opacity: 0.9`, etc.
